### PR TITLE
[WIP] Parse Assemblies

### DIFF
--- a/static/js/rule.js
+++ b/static/js/rule.js
@@ -196,7 +196,6 @@ function parseFieldType(name, arr) {
  * Options are: number, category, feature, description.
  */
 function guessDisplayFields(data, view) {
-
   var res = {
     x: null,
     y: null,
@@ -234,7 +233,7 @@ function guessDisplayFields(data, view) {
   else {
     var keys = ['gc', 'cov', 'len'];
     var avails = [];
-    for (var i = 1; i < keys.length; i++) {
+    for (var i = 0; i < keys.length; i++) {
       var icol = view.spcols[keys[i]];
       if (icol !== null) avails.push(icol);
     }


### PR DESCRIPTION
Hi @qiyunzhu,

I have added code that parses assemblies from megaspades and megahit in .fasta and .fa formats. The code extracts id, length, and coverage from the contig titles and calculates gc from each contig. The web interface takes gc and coverages as the respective x and y variables for the scatterplot. Here are the images of the scatterplots for the megaspades (first image) and megahit (second image) assemblies.

<img width="1080" alt="megaspades_sample_scatterplot" src="https://user-images.githubusercontent.com/74007926/135777695-81eabbda-bf5a-4a74-b4a1-166c20a884c7.PNG">
<img width="1079" alt="megahit_sample_scatterplot" src="https://user-images.githubusercontent.com/74007926/135777705-b76443e3-6f7f-417c-a832-0ef68b476932.PNG">

Thanks,
Abhinav