### PR TITLE
[WIP] Reconversion of Numeric Data to String and back to Numbers

### DIFF
--- a/static/js/operation.js
+++ b/static/js/operation.js
@@ -132,7 +132,7 @@ function parseAssembly(text, data, minLen) {
     if (line.charAt() === '>') { // Checking if the current line is a contig title
         if (id !== null && length >= minLen) {
           // append dataframe with contig title information
-          df.push([id, length.toString(), (gc / length).toString(), coverage]);
+          df.push([id, length, gc / length, coverage]);
         }
         [id, coverage] = parseContigTitles(line, format);
         gc = 0;
@@ -146,7 +146,7 @@ function parseAssembly(text, data, minLen) {
   }
 
   if (id !== null && length >= minLen) {
-    df.push([id, length.toString(), (gc / length).toString(), coverage]);
+    df.push([id, length, gc / length, coverage]);
   }
 
   if (df.length === 0) throw 'Error: No contig is bigger than ' + minLen + ' base pairs.';

--- a/static/js/rule.js
+++ b/static/js/rule.js
@@ -16,6 +16,7 @@
  * @returns {boolean} check result
  */
 function isMissing(str) {
+  str = str.toString();
   var nulls = ['na', 'n/a', 'nan', 'null', ''];
   try {
     str = str.replace(/^[#-]+/, '');
@@ -81,7 +82,7 @@ function parseFieldType(name, arr) {
   if (areNumbers && ((type === '') || (type === 'number'))) {
     var areIntegers = true;
     for (var i = 0; i < arr.length; i++) {
-      if (!isMissing(arr[i]) && (arr[i].indexOf('.') !== -1)) { // has float point
+      if (!isMissing(arr[i]) && (arr[i].toString().indexOf('.') !== -1)) { // has float point
         areIntegers = false;
         break
       }


### PR DESCRIPTION
I have made a few trivial edits in the rule.js file to fix the type reconversion of numeric data to String and back to Numbers. These changes allow us to pass in numeric data in Number format without having to convert the data into a String. 