### PR TITLE
Added contig length and coverage filter

### DIFF
--- a/BinaRena.html
+++ b/BinaRena.html
@@ -1,5 +1,25 @@
 <!doctype html>
 
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>BinaRena</title>
+  <link rel="stylesheet" href="static/vendor/font-awesome/css/font-awesome.min.css">
+  <link rel="stylesheet" href="static/css/style.css">
+  <link rel="stylesheet" href="static/css/theme.css">
+  <script src="static/js/main.js"></script>
+  <script src="static/js/interface.js"></script>
+  <script src="static/js/control.js"></script>
+  <script src="static/js/render.js"></script>
+  <script src="static/js/operation.js"></script>
+  <script src="static/js/util.js"></script>
+  <script src="static/js/numeric.js"></script>
+  <script src="static/js/resource.js"></script>
+  <script src="static/js/rule.js"></script>
+  <script src="static/js/algorithm.js"></script>
+</head>
+
 <!--
   The program interface consists of:
   1. rendering area (main-frame)
@@ -36,26 +56,6 @@
   6. hidden elements:
     file upload button
 -->
-
-<html>
-
-<head>
-  <meta charset="utf-8">
-  <title>BinaRena</title>
-  <link rel="stylesheet" href="static/vendor/font-awesome/css/font-awesome.min.css">
-  <link rel="stylesheet" href="static/css/style.css">
-  <link rel="stylesheet" href="static/css/theme.css">
-  <script src="static/js/main.js"></script>
-  <script src="static/js/interface.js"></script>
-  <script src="static/js/control.js"></script>
-  <script src="static/js/render.js"></script>
-  <script src="static/js/operation.js"></script>
-  <script src="static/js/util.js"></script>
-  <script src="static/js/numeric.js"></script>
-  <script src="static/js/resource.js"></script>
-  <script src="static/js/rule.js"></script>
-  <script src="static/js/algorithm.js"></script>
-</head>
 
 <body>
 
@@ -286,9 +286,12 @@
     <!-- setting panel -->
     <div id="set-panel">
       <button id="set-btn" title="Show settings"><i class="fa fa-sliders fa-lg"></i></button>
-      <div class="dock active">
+      <div class="dock active hidden">
         <div class="panel-head"><span><button disabled>Settings</button></span></div>
         <div class="dash-content">
+          <p><label><b>Filter:</b></label></p>
+          <p><label>Length</label><input type="text" id="len-filt" title="Minimum contig length threshold" style="width: 40%; text-align: right;"></p>
+          <p><label>Coverage</label><input type="text" id="cov-filt" title="Minimum contig coverage threshold" style="width: 40%; text-align: right;"></p>
           <p><label><b>Show:</b></label></p>
           <p><label>Grid</label><input type="checkbox" id="grid-chk"></p>
           <p><label>Navigation bar</label><input type="checkbox" id="nav-chk"></p>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -268,11 +268,10 @@ div.toolbar span.spacer {
 }
 
 #toast-close-btn {
-  font-size: 1.25em;
-  vertical-align: middle;
+  font-size: 1.5em;
   background-color: dimgray;
   color: white;
-  float: right;
+  vertical-align: middle;
 }
 
 #toast-close-btn:hover {
@@ -711,18 +710,12 @@ div.dash-content table tr td:nth-child(2) select {
   margin-left: 2px;
 }
 
-/** setting panel */
-
-#set-panel > div.dock {
-  display: none;
+#widget-frame > div > div.dock {
+  display: flex;
   position: fixed;
   left: 0;
   bottom: 32px;
   flex-direction: column;
-}
-
-#set-panel:hover > div.dock {
-  display: flex;
 }
 
 

--- a/static/js/control.js
+++ b/static/js/control.js
@@ -31,8 +31,9 @@
 function uploadFile(file, mo) {
   var reader = new FileReader();
   reader.onload = function (e) {
-    var cache = updateDataFromText(e.target.result, mo.data);
+    var cache = updateDataFromText(e.target.result, mo.data, mo.view.filter);
     updateViewByData(mo, cache);
+    toastMsg('Read ' + mo.data.df.length + ' contigs.', mo.stat);
   }
   reader.readAsText(file);
 }
@@ -50,8 +51,10 @@ function updateDataFromRemote(path, mo) {
   xhr.onreadystatechange = function() {
     if (this.readyState == 4) {
       if (this.status == 200) {
-        var cache = updateDataFromText(this.responseText, mo.data);
+        var cache = updateDataFromText(this.responseText, mo.data,
+          mo.view.filter);
         updateViewByData(mo, cache);
+        toastMsg('Read ' + mo.data.df.length + ' contigs.', mo.stat);
       }
     }
   }
@@ -293,9 +296,10 @@ function calcDispMinMax(mo, items) {
 function updateViewByData(mo, cache) {
   var data = mo.data;
   var view = mo.view;
+  var n = data.df.length;
 
   // close or open data
-  if (data.df.length === 0) {
+  if (n === 0) {
     document.getElementById('hide-side-btn').click();
     document.getElementById('show-side-btn').disabled = true;
     document.getElementById('drop-sign').classList.remove('hidden');
@@ -322,7 +326,7 @@ function updateViewByData(mo, cache) {
   // calculate total abundance
   if (view.spcols.len && view.spcols.cov) {
     view.abundance = 0;
-    for (var i = 0; i < data.df.length; i++) {
+    for (var i = 0; i < n; i++) {
       view.abundance += data.df[i][view.spcols.len]
         * data.df[i][view.spcols.cov];
     }

--- a/static/js/interface.js
+++ b/static/js/interface.js
@@ -305,6 +305,35 @@ function initControls(mo) {
    * @summary settings panel
    */
 
+  // display settings
+  document.getElementById('set-btn').addEventListener('click',
+    function () {
+    this.classList.toggle('pressed');
+    this.nextElementSibling.classList.toggle('hidden');
+  });
+
+  // change length filter
+  var btn = document.getElementById('len-filt');
+  btn.value = mo.view.filter.len;
+  btn.addEventListener('blur', function () {
+    var val = parseInt(this.value);
+    if (val !== mo.view.filter.len) {
+      mo.view.filter.len = val;
+      toastMsg('Changed contig length threshold to ' + val + '.', mo.stat);
+    }
+  });
+
+  // change coverage filter
+  var btn = document.getElementById('cov-filt');
+  btn.value = mo.view.filter.cov;
+  btn.addEventListener('blur', function () {
+    var val = parseFloat(this.value);
+    if (val != mo.view.filter.cov) {
+      mo.view.filter.cov = val;
+      toastMsg('Changed contig coverage threshold to ' + val + '.', mo.stat);
+    }
+  });
+
   // show/hide grid
   document.getElementById('grid-chk').addEventListener('change', function () {
     view.grid = this.checked;

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -65,6 +65,7 @@ function masterObj() {
    * @property {string} contpal - continuous palette
    * @property {string} discpal - discrete palette
    * @property {number} ncolor - number of categories to color
+   * @property {{len: number, cov: number}} filter - contig filter
    */
   this.view = {
     /** canvas rendering */
@@ -87,6 +88,12 @@ function masterObj() {
     contpal: DEFAULT_CONTINUOUS_PALETTE,
     discpal: DEFAULT_DISCRETE_PALETTE,
     ncolor: 7,
+
+    /** contig filter */
+    filter: {
+      len: 1000,
+      cov: 1.0
+    },
 
     /** indices of special columns */
     spcols: {


### PR DESCRIPTION
This is a feature we previously discussed @AbhinavChede . Two options were added to the setting panel, letting the user specify minimum contig length and coverage thresholds. The default are 1000 and 1.0, respectively. Currently, this feature only works during reading assembly files. It does not work with table files. It also does not filter data that is already read. These need to be resolved in the future.
![Untitled](https://user-images.githubusercontent.com/4396343/146415284-14142391-9c37-49d9-8e74-f62799c85de9.png)

