### PR TITLE
Added loading dots

### DIFF
--- a/BinaRena.html
+++ b/BinaRena.html
@@ -531,6 +531,7 @@
   <!-- toast message -->
   <div id="toast" class="hidden">
     <span id="toast-msg"></span><!--
+    --><span id="loading-dots" class="hidden"><span>&bull;</span> <span>&bull;</span> <span>&bull;</span></span><!--
     --><button id="toast-close-btn" title="Close message" class="hidden">&times;</button>
   </div>
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,11 @@ BinaRena implements several algorithms to calculate binning-related metrics. The
 
 ### Silhouette score
 
+The [silhouette coefficient](https://en.wikipedia.org/wiki/Silhouette_(clustering)) measures how similar a contig is to other contigs in the same bin, as in contrast to contigs in other bins. It ranges from -1 (worse) to 1 (best). The silhouette score, i.e., the mean silhouette coefficient of all contigs, evaluates the quality of a binning plan.
+
 ### Adjusted Rand index
+
+The [adjusted Rand index](https://en.wikipedia.org/wiki/Rand_index) (ARI) measures the consistency between two binning plans. Higher is better. Two identical plans have ARI = 1. Two random plans will have an ARI close to 0.
 
 
 ## Contact

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -324,6 +324,14 @@ div.toolbar span.spacer {
   background-color: lightgray;
 }
 
+/* loading dots */
+#loading-dots { margin-right: 10px;}
+#loading-dots > span { animation: blinking 1.2s linear infinite; }
+#loading-dots > span:nth-child(1) { animation-delay: 0.4s; }
+#loading-dots > span:nth-child(2) { animation-delay: 0.8s; }
+#loading-dots > span:nth-child(3) { animation-delay: 1.2s; }
+@keyframes blinking { from { opacity: 0; } to { opacity: 1; } }
+
 
 /** modal */
 

--- a/static/js/algorithm.js
+++ b/static/js/algorithm.js
@@ -65,25 +65,21 @@ function pnpoly(x, y, polygon) {
 /**
  * Compute the silhouette coefficient for each contig.
  * @function silhouetteSample
- * @param {number[]} x - the input data array
- * @param {number[]} label - the label of input data (must be 0, 1, 2...)
+ * @param {number[]} x - input data
+ * @param {number[]} label - labels of input data
+ * @param {number[]} dist - pairwise distances among input data
  * @return {number[]} silhouette coefficient of each contig
  * @description The silhouette coefficient measures how similar a contig is to
  * other contigs in the same bin, as in contrast to contigs in other bins.
  * @see {@link https://en.wikipedia.org/wiki/Silhouette_(clustering)}
  * @description It requires calculation of a distance matrix of all contigs,
- * which is expensive. The distance matrix should be cached to avoid repeated
- * calculations
+ * which is expensive. Therefore it is pre-calculated, stored, and fed to the
+ * current function.
  */
-function silhouetteSample(x, label) {
+function silhouetteSample(x, label, dist) {
   var n = x.length;
   var count = bincount(label); // bin sizes
   var c = count.length;
-
-  // var t0 = performance.now();
-  var dist = pdist(x);  // pairwise distances of all contigs
-  // var t1 = performance.now();
-  // console.log(t1 - t0);
 
   // intermediates
   var distIn;  // intra-bin distance
@@ -158,7 +154,7 @@ function silhouetteScore(x, label) {
 /**
  * @summary Adjusted Rand index (ARI)
  * @description The adjusted Rand index (ARI) measures the similarity between
- * binning plans (sets of bins).
+ * two binning plans (sets of bins).
  * @see {@link https://en.wikipedia.org/wiki/Rand_index}
  */
 

--- a/static/js/interface.js
+++ b/static/js/interface.js
@@ -1125,7 +1125,7 @@ function initCanvas(mo) {
     // var t1 = performance.now();
     // console.log(t1 - t0);
   });
-}
+} // end initializing controls
 
 
 /**
@@ -1387,16 +1387,16 @@ function scale2HTML(scale) {
  * @param {string} msg - message to display
  * @param {Object} stat - status object
  * @param {number} duration - milliseconds to keep toast visible; if omitted,
- * the default time is 1 sec; set 0 to keep it visible for ever until the user
- * clicks the "close" button.
+ * the default time is 1 sec; set 0 to keep it visible for ever
+ * @param {boolean} loading - display loading dots
+ * @param {boolean} toclose - display a close button
  */
-function toastMsg(msg, stat, duration) {
-  if (duration === undefined) {
-    duration = 1000;
-  }
+function toastMsg(msg, stat, duration, loading, toclose) {
+  if (duration === undefined) duration = 1000;
   var toast = byId('toast');
   toast.firstElementChild.innerHTML = msg;
-  toast.lastElementChild.classList.toggle('hidden', duration);
+  byId('loading-dots').classList.toggle('hidden', !loading);
+  byId('toast-close-btn').classList.toggle('hidden', !toclose);
   toast.classList.remove('hidden');
   if (duration) {
     clearTimeout(stat.toasting);

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -33,6 +33,7 @@
  * @property {Object} rena - arena canvas DOM
  * @property {Object} oray - overlay canvas DOM
  * @property {Object} mini - mini plot
+ * @property {number[]} dist - pairwise distances among all contigs 
  * @property {Object} palettes - available palettes
  */
 function mainObj() {
@@ -186,19 +187,32 @@ function mainObj() {
    * @property {number} field - field index of data to plot
    * @property {boolean} log - whether log-transform data
    * @property {number} nbin - number of bins in histogram
-   * @property {number} cbin - index of current bin (null if none)
+   * @property {number[]} hist - saved bin sizes
+   * @property {number[]} edges - saved bin edges
+   * @property {number} bin0 - first bin in selection range
+   * @property {number} bin0 - last bin in selection range
+   * @property {number} drag - mouse dragging starting position
    */
   this.mini = {
     canvas: null,
-    field: null,
-    log: false,
-    nbin: 10,
-    hist: null,
-    edges: null,
-    bin0: null, // first bin
-    bin1: null, // last bin
-    drag: null,
+    field:  null,
+    log:   false,
+    nbin:     10,
+    hist:   null,
+    edges:  null,
+    bin0:   null,
+    bin1:   null,
+    drag:   null,
   }
+
+  /**
+   * Pairwise distances
+   * @member {Array} dist
+   * @description Pairwise distances among all contigs, stored as a condensed
+   * distance matrix (a 1D array). Calculating such a matrix is expensive,
+   * therefore it is cached here to avoid duplicated calculations.
+   */
+  this.dist = null;
 }
 
 


### PR DESCRIPTION
Some calculations are heavy. Therefore having some animation indicating that the program is running rather than frozen is necessary. This PR added loading dots to the toast message box. Currently it only works for silhouette score calculation, but it shouldn't be hard to ported to other calculations (especially loading big files).

![Peek 2021-12-19 13-47](https://user-images.githubusercontent.com/4396343/146690351-0071466a-a325-42df-a4f1-f9dfe2d6beac.gif)


Also improved silhouette score calculation. The distance matrix is cached once calculated, to avoid expensive re-calculation.