### PR TITLE
Trying to address pdist memory limitation

### DIFF
--- a/BinaRena.html
+++ b/BinaRena.html
@@ -571,7 +571,7 @@
       <div class="modal-body">
         <table style="border-collapse: separate;">
           <tr>
-            <td rowspan="4" style="padding-right: 25px;"><img src="path/to/logo.png" alt="BinaRena" width="200" height="176"></td>
+            <!-- <td rowspan="4" style="padding-right: 25px;"><img src="path/to/logo.png" alt="BinaRena" width="200" height="176"></td> -->
             <td><big>BinaRena</big></td>
           </tr>
           <tr><td>Version: 0.0.1</td></tr>

--- a/README.md
+++ b/README.md
@@ -321,9 +321,15 @@ The contigs are filtered to exclude those 1) that are not in any bin, 2) that ar
 
 One can monitor the process and intermediates using the browser's **console**.
 
-**Why does the program stall during silhouette coefficient calculation?**
+**Why does the program stall / crash during silhouette coefficient calculation?**
 
-Calculation of silhouette coefficients requires the calculation of a Euclidean distance matrix among all contigs. This is a computationally expensive operation, and runtime quickly builds up as the dataset expands (_O_(_n_<sup>2</sup>)). However, with a typical computer, it shouldn't take more than a few minutes even with tens of thousands of contigs. Just be bit patient before killing the browser tab.
+Calculation of silhouette coefficients requires the calculation of a Euclidean distance matrix among all contigs. This is a computationally expensive operation. Runtime and memory consumption quickly build up as the dataset expands (_O_(_n_<sup>2</sup>)).
+
+However, with a typical computer, it shouldn't take more than a few minutes even with tens of thousands of contigs. Just be bit patient before killing the browser tab.
+
+- Note: Chrome and Edge have a mechanism to limit memory consumption per tab, hence blocking this function from handling more than some ten thousand of contigs. Firefox and Safari do not have this limitation.
+
+When compute is an issue, it is recommended to filter down the dataset (e.g., removing short and shallow contigs) to make the calculation smooth.
 
 
 ## Contact

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 **Binarena** ("bin arena") is an interative visualizer of metagenomic assembly that facilitates observation, semi-manual and semi-automatic binning of metagenomic contigs.
 
 
-## [live demo](https://qiyunlab.github.io/binarena/demo.html)
+## [Live demo](https://qiyunlab.github.io/binarena/demo.html)
 
 Please check out this [live demo](https://qiyunlab.github.io/binarena/demo.html). It is a fully functional program with a pre-loaded sample [dataset](https://www.ncbi.nlm.nih.gov/assembly/GCA_003604395.1/). You may close the data, then drag and drop your own data into the interface and start to analyze!
 
@@ -321,9 +321,9 @@ The contigs are filtered to exclude those 1) that are not in any bin, 2) that ar
 
 One can monitor the process and intermediates using the browser's **console**.
 
-**Why does program crash / stall during silhouette coefficient calculation?**
+**Why does the program stall during silhouette coefficient calculation?**
 
-Calculation of silhouette coefficients requires the calculation of a Euclidean distance matrix among all contigs. This is a computationally expensive operation (_O_(_n_<sup>2</sup>)). However, with a typical computer, it shouldn't take more than 1-2 minutes. The most plausible reason for stalling is that there are too many data points and this causes an out-of-memory error (can be found in the browser console). In that case, one should filter down the contigs and try again.
+Calculation of silhouette coefficients requires the calculation of a Euclidean distance matrix among all contigs. This is a computationally expensive operation, and runtime quickly builds up as the dataset expands (_O_(_n_<sup>2</sup>)). However, with a typical computer, it shouldn't take more than a few minutes even with tens of thousands of contigs. Just be bit patient before killing the browser tab.
 
 
 ## Contact

--- a/static/js/algorithm.js
+++ b/static/js/algorithm.js
@@ -113,7 +113,7 @@ function silhouetteSample(x, label, dist) {
         }
 
         // determine intra- or inter-bin distance
-        if (li == label[j]) {
+        if (li === label[j]) {
           distIn += dist[idx];
         } else {
           distOut[label[j]] += dist[idx];
@@ -138,6 +138,40 @@ function silhouetteSample(x, label, dist) {
       res[i] = 0;
     }
   } // end for i
+  return res;
+}
+
+
+/**
+ * Compute the silhouette coefficient for each contig.
+ * @function silhouetteSample2D
+ * @param {number[]} x - input data
+ * @param {number[]} label - labels of input data
+ * @param {number[]} dist - pairwise distances among input data
+ * @return {number[]} silhouette coefficient of each contig
+ * @description This is the 2D version of the function.
+ */
+ function silhouetteSample2D(x, label, dist) {
+  const n = x.length;
+  const count = bincount(label);
+  const c = count.length;
+  let distIn, distOut, li, j;
+  const res = Array(n).fill();
+  for (let i = 0; i < n; i++) {
+    li = label[i];
+    if (count[li] > 1) {
+      distIn = 0;
+      distOut = Array(c).fill(0);
+      for (j = 0; j < n; j++) {
+        if (li === label[j]) distIn += dist[i][j];
+        else distOut[label[j]] += dist[i][j];
+      }
+      for (j = 0; j < c; j++) distOut[j] /= count[j];
+      distOut = Math.min.apply(null, distOut.filter(Boolean));
+      distIn /= (count[li] - 1);
+      res[i] = (distOut - distIn) / Math.max(distOut, distIn);
+    } else res[i] = 0;
+  }
   return res;
 }
 

--- a/static/js/calculate.js
+++ b/static/js/calculate.js
@@ -177,11 +177,21 @@ function calcSilhouette(mo) {
     // if (cache.pdist.length === 0) cache.pdist = pdist(vals);
     // note: can no longer use cache pdist
     console.log('Calculating pairwise Euclidean distances...');
-    const dm = pdist(vals);
+
+    // switch to 2D version if there are too many contigs
+    const use2d = n_ctg >= 20000;
+    if (use2d) console.log('Switched to 2D calculation (slower but can ' +
+      'handle more data points.');
+
+    // const t0 = performance.now();
+    const dm = use2d ? pdist2d(vals) : pdist(vals);
+    // const t1 = performance.now();
+    // console.log(t1 - t0);
 
     // calculate silhouette scores
     console.log('Calculating silhouette coefficients...');
-    let scores = silhouetteSample(vals, labels, dm);
+    let scores = use2d ? silhouetteSample2D(vals, labels, dm) :
+      silhouetteSample(vals, labels, dm);
 
     // cache result
     console.log('Calculation completed.');

--- a/static/js/numeric.js
+++ b/static/js/numeric.js
@@ -437,6 +437,42 @@ function pdist(arr) {
 
 
 /**
+ * Calculate pairwise distances of all data points
+ * @function pdist
+ * @param {number[][]} arr - input data
+ * @return {number[][]} distance matrix
+ * @description This is the 2D version of pdist. It returns a 2D matrix
+ * instead of a 1D condensed matrix. This is because JavaScript has an upper
+ * limit of array length (2^32-1 = 4,294,967,295). A large dataset may exceed
+ * this limit.
+ */
+function pdist2d(arr) {
+  const n = arr.length;
+  const m = arr[0].length;
+  const res = Array(n).fill().map(() => Array(n).fill(0));
+  let xi, xj, sum, k;
+  for (let i = 0; i < n; i++) {
+    xi = arr[i];
+    for (let j = 0; j < n; j++) {
+      if (j === i) {
+        res[i][j] = 0;
+      } else if (j < i) {
+        res[i][j] = res[j][i];
+      } else {
+        xj = arr[j];
+        sum = 0;
+        for (k = 0; k < m; k++) {
+          sum += (xi[k] - xj[k]) ** 2;
+        }
+        res[i][j] = Math.sqrt(sum);
+      }
+    }
+  }
+  return res;
+}
+
+
+/**
  * Convert a categorical variable to incremental integers.
  * @param {string[]} arr - input array
  * @returns {number[], string[]} factorized variable and unique values

--- a/tests/algorithm.test.js
+++ b/tests/algorithm.test.js
@@ -16,6 +16,16 @@ describe('algorithm.js', function() {
     expect(silhouetteSample(x1, label1, pdist(x1))).toEqual([1/3, 1/3, 1/3, 1/3]);
   });
 
+  it('silhouetteSample2D', function() {
+    let x0 = [[5, 0], [3, 3], [7, 9]];
+    let label0 = [0, 0, 1];
+    expect(silhouetteSample2D(x0, label0, pdist2d(x0)))
+      .toEqual([(Math.sqrt(85) - Math.sqrt(13)) / Math.sqrt(85), 0.5, 0]);
+    let x1 = [[3, 0], [0, 4], [3, 4], [0, 0]];
+    let label1 = [0, 1, 1, 0];
+    expect(silhouetteSample2D(x1, label1, pdist2d(x1))).toEqual([1/3, 1/3, 1/3, 1/3]);
+  });
+
   it('coordinateMatrix', function() {
     expect(coordinateMatrix([0, 2, 2], [0, 1, 2], [2, 3, 1], [4, 4]))
       .toEqual([[2, 0, 0, 0], [0, 0, 0, 0], [0, 3, 1, 0], [0, 0, 0, 0]]);


### PR DESCRIPTION
JavaScript has a array length limitation of 2^32-1, which can be exceeded by tens of thousands of contigs during pairwise distance calculation (O(n^2)). Therefore, I implemented a mechanism to switch from the faster condensed distance matrix to the slower and more memory hungry square distance matrix if there are more than 20,000 data points. This solves the problem on Firefox and Safari.

However, Chrome and Edge has a mechanism to prevent a browser tab from using too much memory. The current patch won't break this limitation.

Noted in the documentation.