### PR TITLE
Silhouette calculation on large dataset

### DIFF
--- a/static/js/calculate.js
+++ b/static/js/calculate.js
@@ -181,24 +181,42 @@ function calcSilhouette(mo) {
     const vals = transpose(filt_data);
 
     // calculate pairwise distance if not already
+
+    // in JavaScript, the maximum array size is 2 ** 32 - 1 = 4,294,967,295
+    // a condensed distance matrix for n data points has n * (n - 1) / 2
+    // elements, therefore the maximum number of data points is 92,681, which
+    // translates into 4,294,837,540 elements
+
     // if (cache.pdist.length === 0) cache.pdist = pdist(vals);
     // note: can no longer use cache pdist
-    console.log('Calculating pairwise Euclidean distances...');
+
+    let scores;
+    if (n_ctg < 20000) {
+      console.log('Calculating pairwise Euclidean distances...');
+      const dm = pdist(vals);
+      console.log('Calculating silhouette coefficients...');
+      scores = silhouetteSamplePre(dm, labels, n_ctg);
+    }
+    else {
+      console.log('Calculating silhouette coefficients...');
+      scores = silhouetteSampleIns(vals, labels);
+    }
 
     // switch to 2D version if there are too many contigs
-    const use2d = n_ctg >= 20000;
-    if (use2d) console.log('Switched to 2D calculation (slower but can ' +
-      'handle more data points.');
+    // const use2d = n_ctg >= 20000;
+    // if (use2d) console.log('Switched to 2D calculation (slower but can ' +
+    //   'handle more data points.');
 
     // const t0 = performance.now();
-    const dm = use2d ? pdist2d(vals) : pdist(vals);
+    // const dm = use2d ? pdist2d(vals) : pdist(vals);
     // const t1 = performance.now();
     // console.log(t1 - t0);
 
     // calculate silhouette scores
-    console.log('Calculating silhouette coefficients...');
-    let scores = use2d ? silhouetteSample2D(vals, labels, dm) :
-      silhouetteSample(vals, labels, dm);
+    // console.log('Calculating silhouette coefficients...');
+    // const scores = silhouetteSampleIns(vals, labels);
+    // let scores = use2d ? silhouetteSample2D(vals, labels, dm) :
+    //   silhouetteSample(vals, labels, dm);
 
     // cache result
     console.log('Calculation completed.');

--- a/tests/algorithm.test.js
+++ b/tests/algorithm.test.js
@@ -6,24 +6,36 @@
 
 describe('algorithm.js', function() {
 
-  it('silhouetteSample', function() {
+  it('silhouetteSamplePre', function() {
     let x0 = [[5, 0], [3, 3], [7, 9]];
     let label0 = [0, 0, 1];
-    expect(silhouetteSample(x0, label0, pdist(x0)))
+    expect(silhouetteSamplePre(pdist(x0), label0, x0.length))
       .toEqual([(Math.sqrt(85) - Math.sqrt(13)) / Math.sqrt(85), 0.5, 0]);
     let x1 = [[3, 0], [0, 4], [3, 4], [0, 0]];
     let label1 = [0, 1, 1, 0];
-    expect(silhouetteSample(x1, label1, pdist(x1))).toEqual([1/3, 1/3, 1/3, 1/3]);
+    expect(silhouetteSamplePre(pdist(x1), label1, x1.length)).toEqual([
+      1/3, 1/3, 1/3, 1/3]);
   });
 
-  it('silhouetteSample2D', function() {
+  it('silhouetteSampleIns', function() {
     let x0 = [[5, 0], [3, 3], [7, 9]];
     let label0 = [0, 0, 1];
-    expect(silhouetteSample2D(x0, label0, pdist2d(x0)))
+    expect(silhouetteSampleIns(x0, label0))
       .toEqual([(Math.sqrt(85) - Math.sqrt(13)) / Math.sqrt(85), 0.5, 0]);
     let x1 = [[3, 0], [0, 4], [3, 4], [0, 0]];
     let label1 = [0, 1, 1, 0];
-    expect(silhouetteSample2D(x1, label1, pdist2d(x1))).toEqual([1/3, 1/3, 1/3, 1/3]);
+    expect(silhouetteSampleIns(x1, label1)).toEqual([1/3, 1/3, 1/3, 1/3]);
+  });
+
+  it('silhouetteSamplePre2D', function() {
+    let x0 = [[5, 0], [3, 3], [7, 9]];
+    let label0 = [0, 0, 1];
+    expect(silhouetteSamplePre2D(pdist2d(x0), label0))
+      .toEqual([(Math.sqrt(85) - Math.sqrt(13)) / Math.sqrt(85), 0.5, 0]);
+    let x1 = [[3, 0], [0, 4], [3, 4], [0, 0]];
+    let label1 = [0, 1, 1, 0];
+    expect(silhouetteSamplePre2D(pdist2d(x1), label1)).toEqual([
+      1/3, 1/3, 1/3, 1/3]);
   });
 
   it('coordinateMatrix', function() {


### PR DESCRIPTION
This solution calculates pairwise distances in real-time rather than pre-calculating and storing the distance matrix in the memory. Therefore it is memory efficient, despite twice as slow (because each pair is calculated twice). It is necessary for handling very large datasets.

In the following example, calculating Silhouette coefficients of ~250k data points assigned to ~250 clusters took about 20 min.

@pavia27 @nujinuji 

![Screenshot from 2022-06-02 10-58-27](https://user-images.githubusercontent.com/4396343/171697311-93e76f46-8179-4d63-bc05-4940b8ce8e9a.png)

