### PR TITLE
Added progress bar and stop button for silhouette

### DIFF
--- a/BinaRena.html
+++ b/BinaRena.html
@@ -612,11 +612,11 @@
     <div class="modal-content">
       <div class="modal-head">
         <span>
-          <button id="silh-done-btn">Done</button><button id="silh-calc-btn">Calculate</button>
+          <button id="silh-done-btn">Done</button><button id="silh-stop-btn">Abort</button><button id="silh-calc-btn">Calculate</button>
         </span>
         <span>
           <span id="silh-title">Silhouette coefficient</span>
-          <span id="silh-progress">Calculating&nbsp;&nbsp;<span class="prog-dots"><span>&bull;</span> <span>&bull;</span> <span>&bull;</span></span></span>
+          <span id="silh-progress"><span>Calculating</span>&nbsp;&nbsp;<span class="prog-dots"><span>&bull;</span> <span>&bull;</span> <span>&bull;</span></span></span>
         </span>
         <span><button id="silh-help-btn">&quest;</button></span>
       </div>
@@ -631,6 +631,9 @@
               <tr><td><input type="checkbox" id="opacity-calc-chk">&nbsp;Opacity:</td><td id="opacity-calc-var"></td></tr>
               <tr><td><input type="checkbox" id="color-calc-chk">&nbsp;Color:</td><td id="color-calc-var"></td></tr>
             </table>
+            <div id="silh-flag-div">
+              <p title="Display % progress and an &quot;abort&quot; button during calculation, which however is slower than not"><input type="checkbox" id="silh-progress-chk" checked>&nbsp;Interactive mode</p>
+            </div>
             <div id="silh-done-div" class="hidden">
               <p>Calculation completed.</p>
               <table id="silh-res-todo">

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -317,6 +317,8 @@ function mainObj() {
    * @property {Array.<{x: number, y: number}>} polygon - vertices of polygon
    * @property {number}   resizing  - window resizing is ongoing
    * @property {number}   toasting  - toasting is ongoing
+   * @property {number}   stopping  - calculation is stopping
+   * @property {number}   progress  - calculation progress
    */
   this.stat = {
     mousedown: false,
@@ -328,7 +330,9 @@ function mainObj() {
     drawing:   false,
     polygon:   [],
     resizing:  null,
-    toasting:  null
+    toasting:  null,
+    stopping:  false,
+    progress:  null
   };
 
 

--- a/static/js/select.js
+++ b/static/js/select.js
@@ -229,7 +229,7 @@ function clearHighlight(mo, idx, btn) {
   }
   btn.previousSibling.innerHTML = '&nbsp;';
   btn.classList.add('hidden');
-  renderArena(mo);
+  renderArena(mo, true);
 }
 
 


### PR DESCRIPTION
Silhouette coefficient calculation takes a long time, so it will be preferrable to display the % progress interactively and allow the user to stop a lengthy run. This pull request implements it. However, the interactive method is twice as slow as the non-interactive one. Both are options for the user.