### PR TITLE
Added fallback for requestIdleCallback

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -501,6 +501,29 @@ const byId = (id) => document.getElementById(id);
 
 
 /**
+ * @summary Fallback for `requestIdleCallback`.
+ * @description For browser compatibility (esp. Safari).
+ * @see {@link: https://developer.chrome.com/blog/using-requestidlecallback/}
+ */
+window.requestIdleCallback = window.requestIdleCallback ||
+  function (cb) {
+    const start = Date.now();
+    return setTimeout(function () {
+      cb({
+        didTimeout: false,
+        timeRemaining: function () {
+          return Math.max(0, 50 - (Date.now() - start));
+        }
+      });
+    }, 1);
+  }
+window.cancelIdleCallback = window.cancelIdleCallback ||
+  function (id) {
+    clearTimeout(id);
+  }
+
+
+/**
  * @summary Window load event, also top-level entry for all functions.
  */
 window.addEventListener('load', function () {


### PR DESCRIPTION
Currently Safari doesn't support this function, so added this fallback.